### PR TITLE
Fix MediaLibraryV9Upgrade upward migration to run properly on MariaDB

### DIFF
--- a/database/migrations/2021_04_15_232615_medialibrary_v9_upgrade.php
+++ b/database/migrations/2021_04_15_232615_medialibrary_v9_upgrade.php
@@ -24,7 +24,7 @@ class MediaLibraryV9Upgrade extends Migration {
             ->orWhere('generated_conversions', '')
             ->orWhereRaw("JSON_TYPE(generated_conversions) = 'NULL'")
             ->update([
-                'generated_conversions' => DB::raw('custom_properties->"$.generated_conversions"'),
+                'generated_conversions' => DB::raw("JSON_EXTRACT(custom_properties, '$.generated_conversions')"),
                 // OPTIONAL: Remove the generated conversions from the custom_properties field as well:
                 // 'custom_properties'     => DB::raw("JSON_REMOVE(custom_properties, '$.generated_conversions')")
             ]);


### PR DESCRIPTION
As MySQL JSON extract arrow operator (`->``) is not supported on MariaDB as of 10.7 version, utilize JSON_EXTRACT instead.